### PR TITLE
Use the new scalariform sbt-plugin in the CoreSettingsPlugin.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,12 @@
 import bintray.{ Keys => BintrayKeys }
 import bintray.{ Plugin => BintrayPlugin }
 
-libraryDependencies ++= Seq("com.typesafe" % "config" % "1.2.0")
+libraryDependencies ++= Seq("com.typesafe" % "config" % "1.2.0",
+  // This seems to be required in order to pick up the newer scalariform version; either the exclude
+  // below doesn't work with sbt plugins, or the old version is being brought in through a different
+  // dependency.
+  "com.github.jkinkead" %% "scalariform" % "0.1.6"
+)
 
 organization := "org.allenai.plugins"
 
@@ -27,9 +32,12 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.6")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+addSbtPlugin(
+  ("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+    // Exclude the old scalariform fork - we include a newer version with sbt-scalariform below.
+    .exclude("com.danieltrinh", "scalariform"))
 
-addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("com.github.jkinkead" % "sbt-scalariform" % "0.1.6")
 
 // Dependency graph visualiztion in SBT console
 addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.4")

--- a/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
@@ -3,10 +3,13 @@ package org.allenai.plugins
 import sbt._
 import sbt.Keys._
 
+import scalariform.formatter.preferences.{ DoubleIndentClassDeclaration, FormattingPreferences }
+import scalariform.sbt.ScalariformPlugin
+
 object CoreSettingsPlugin extends AutoPlugin {
 
   // Automatically add the StylePlugin and VersionInjectorPlugin
-  override def requires: Plugins = StylePlugin && VersionInjectorPlugin
+  override def requires: Plugins = ScalariformPlugin && StylePlugin && VersionInjectorPlugin
 
   // Automatically enable the plugin (no need for projects to `enablePlugins(CoreSettingsPlugin)`)
   override def trigger: PluginTrigger = allRequirements
@@ -27,6 +30,10 @@ object CoreSettingsPlugin extends AutoPlugin {
         conflictManager := ConflictManager.strict,
         resolvers ++= CoreRepositories.Resolvers.defaults,
         dependencyOverrides ++= CoreDependencies.loggingDependencyOverrides,
-        dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value
+        dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value,
+        // Override default scalariform settings.
+        ScalariformPlugin.autoImport.scalariformPreferences := {
+          FormattingPreferences().setPreference(DoubleIndentClassDeclaration, true)
+        }
       )
 }

--- a/src/main/scala/org/allenai/plugins/StylePlugin.scala
+++ b/src/main/scala/org/allenai/plugins/StylePlugin.scala
@@ -3,37 +3,17 @@ package org.allenai.plugins
 import sbt._
 import sbt.Keys._
 
-import com.typesafe.sbt.SbtScalariform._
 import org.scalastyle.sbt.{
   ScalastylePlugin,
   Tasks => ScalastyleTasks
-
 }
-import scalariform.formatter.ScalaFormatter
-import scalariform.formatter.preferences._
-import scalariform.parser.ScalaParserException
-
-import java.io.File
 
 /** Plugin wrapping the scalastyle SBT plugin. This uses the configuration resource in this package
   * to configure scalastyle, and sets up test and compile to depend on it.
   */
 object StylePlugin extends AutoPlugin {
-  lazy val formattingPreferences = {
-    FormattingPreferences().
-      setPreference(DoubleIndentClassDeclaration, true).
-      setPreference(MultilineScaladocCommentsStartOnFirstLine, true).
-      setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
-  }
-
   object StyleKeys {
     val styleCheck = TaskKey[Unit]("styleCheck", "Check scala file style using scalastyle")
-    val format = TaskKey[Seq[File]]("format", "Format scala sources using scalariform")
-    val formatCheck = TaskKey[Seq[File]]("formatCheck", "Check scala sources using scalariform")
-    val formatCheckStrict = TaskKey[Unit](
-      "formatCheckStrict",
-      "Check scala sources using scalariform, failing if an unformatted file is found"
-    )
   }
 
   override def requires: Plugins = plugins.JvmPlugin
@@ -41,46 +21,21 @@ object StylePlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    // Add default scalariform + scalastyle settings.
-    defaultScalariformSettings ++
-      ScalastylePlugin.projectSettings ++
+    // Add scalastyle settings.
+    ScalastylePlugin.projectSettings ++
       // Add our default settings to test & compile.
       inConfig(Compile)(configSettings) ++
       inConfig(Test)(configSettings) ++
-      // Check format & style on compile.
-      // Putting format second means it gets evaluated first in SBT. Same with the Test checks.
       Seq(
+        // Check style on compile.
         compileInputs in (Test, compile) <<=
           (compileInputs in (Test, compile)) dependsOn (StyleKeys.styleCheck in Test),
-        compileInputs in (Test, compile) <<=
-          (compileInputs in (Test, compile)) dependsOn (StyleKeys.formatCheck in Test),
         compileInputs in (Compile, compile) <<=
-          (compileInputs in (Compile, compile)) dependsOn (StyleKeys.styleCheck in Compile),
-        compileInputs in (Compile, compile) <<=
-          (compileInputs in (Compile, compile)) dependsOn (StyleKeys.formatCheck in Compile),
-        // scalariform settings
-        ScalariformKeys.preferences := formattingPreferences
+          (compileInputs in (Compile, compile)) dependsOn (StyleKeys.styleCheck in Compile)
       )
 
   // Settings used for a particular configuration (such as Compile).
   def configSettings: Seq[Setting[_]] = Seq(
-    StyleKeys.format := ScalariformKeys.format.value,
-    StyleKeys.formatCheck := checkFormatting(
-      ScalariformKeys.preferences.value,
-      (sourceDirectories in ScalariformKeys.format).value.toList,
-      (includeFilter in ScalariformKeys.format).value,
-      (excludeFilter in ScalariformKeys.format).value,
-      thisProjectRef.value,
-      configuration.value,
-      streams.value,
-      scalaVersion.value
-    ),
-    StyleKeys.formatCheckStrict <<= (StyleKeys.formatCheck) map { files: Seq[File] =>
-      if (files.size > 0) {
-        throw new IllegalArgumentException("Unformatted files.")
-
-      }
-    },
     StyleKeys.styleCheck := {
       // "q" for "quiet".
       val args = Seq("q")
@@ -101,9 +56,7 @@ object StylePlugin extends AutoPlugin {
         0, // How frequently, in hours, to refresh config from URL. Ignored if URL is None.
         target.value,
         "/dev/null" // URL cache file. Ignored if URL is None.
-
       )
-
     }
   )
 
@@ -132,48 +85,5 @@ object StylePlugin extends AutoPlugin {
 
     }
     destinationFile
-
   }
-
-  def checkFormatting(
-    preferences: IFormattingPreferences,
-    sourceDirectories: Seq[File],
-    includeFilter: FileFilter,
-    excludeFilter: FileFilter,
-    ref: ProjectRef,
-    configuration: Configuration,
-    streams: TaskStreams,
-    scalaVersion: String
-  ): Seq[File] = {
-
-    def unformattedFiles(files: Set[File]): Set[File] =
-      for {
-        file <- files if file.exists
-        contents = IO.read(file)
-        formatted = try {
-          ScalaFormatter.format(
-            contents,
-            preferences,
-            scalaVersion = pureScalaVersion(scalaVersion)
-          )
-        } catch {
-          case e: ScalaParserException =>
-            streams.log.error("Scalariform parser error for %s: %s".format(file, e.getMessage))
-            contents
-        }
-        if formatted != contents
-      } yield (file)
-
-    streams.log("Checking scala formatting...")
-    val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get.toSet
-    val unformatted = unformattedFiles(files).toSeq sortBy (_.getName)
-    for (file <- unformatted) {
-      streams.log.error(f"misformatted: ${file.getName}")
-    }
-
-    unformatted
-  }
-
-  def pureScalaVersion(scalaVersion: String): String =
-    scalaVersion.split("-").head
 }


### PR DESCRIPTION
I'm a little worried that this still seems to pull in the old scalariform version in as a dependency; I suspect (as noted in `build.sbt`) that the exclude isn't working for some reason.

I think this should be compatible with the existing jar in the github hook package, but I'll republish in a bit to make sure.